### PR TITLE
Load file references without building

### DIFF
--- a/combine/core.py
+++ b/combine/core.py
@@ -105,6 +105,7 @@ class Combine:
                     continue
 
                 try:
+                    file.load(self.jinja_environment)
                     file.render(
                         output_path=self.output_path,
                         jinja_environment=self.jinja_environment,

--- a/combine/core.py
+++ b/combine/core.py
@@ -27,32 +27,46 @@ class Combine:
 
     def load(self):
         self.config = Config(self.config_path)
-        self.output_path = self.config.output_path
-        self.content_paths = self.config.content_paths
 
-        self.content_directories = [ContentDirectory(x) for x in self.content_paths]
+        self.jinja_environment = self.get_jinja_environment(
+            content_paths=self.config.content_paths,
+            variables=self.get_jinja_variables(self.config.variables),
+        )
 
-        choice_loaders = [
-            jinja2.FileSystemLoader(x.path) for x in self.content_directories
-        ]
+        self.content_directories = []
+        for path in self.config.content_paths:
+            cd = ContentDirectory(path)
+            cd.load(self.jinja_environment)
+            self.content_directories.append(cd)
 
-        self.jinja_environment = jinja2.Environment(
+    @property
+    def output_path(self):
+        return self.config.output_path
+
+    def get_jinja_environment(self, content_paths, variables):
+        choice_loaders = [jinja2.FileSystemLoader(x) for x in content_paths]
+
+        jinja_environment = jinja2.Environment(
             loader=jinja2.ChoiceLoader(choice_loaders),
             autoescape=jinja2.select_autoescape(["html", "xml"]),
             undefined=jinja2.StrictUndefined,  # make sure variables exist
             extensions=default_extensions,
         )
-        self.jinja_environment.globals.update(self.get_jinja_variables())
-        self.jinja_environment.filters.update(default_filters)
+        jinja_environment.globals.update(variables)
+        jinja_environment.filters.update(default_filters)
 
-    def get_jinja_variables(self):
+        return jinja_environment
+
+    def get_jinja_variables(self, config_variables):
         """
         1. combine.yml variables
         2. Combine object variables (CLI, Python, etc.) that should override
         3. Built-in variables
         """
-        variables = self.config.variables
-        variables.update(self.variables)
+        variables = {
+            **config_variables,
+            **self.variables,
+        }
 
         if "env" in variables:
             raise ReservedVariableError("env")
@@ -143,7 +157,7 @@ class Combine:
         return files
 
     def content_relative_path(self, path):
-        for content_path in self.content_paths:
+        for content_path in self.config.content_paths:
             if (
                 os.path.commonpath([content_path, path]) != os.getcwd()
                 and os.getcwd() in content_path
@@ -165,15 +179,16 @@ class ContentDirectory:
     def __init__(self, path):
         assert os.path.exists(path), f"Path does not exist: {path}"
         self.path = path
-        self.load_files()
 
-    def load_files(self):
+    def load(self, jinja_environment):
         self.files = []
 
         for root, dirs, files in os.walk(self.path, followlinks=True):
             for file in files:
                 file_path = os.path.join(root, file)
-                self.files.append(file_class_for_path(file_path)(file_path, self))
+                file_obj = file_class_for_path(file_path)(file_path, self)
+                file_obj.load(jinja_environment)
+                self.files.append(file_obj)
 
     def file_classes(self):
         return set([x.__class__ for x in self.files])

--- a/combine/files/core.py
+++ b/combine/files/core.py
@@ -24,6 +24,10 @@ class File:
     def _get_output_relative_path(self):
         return self.content_relative_path
 
+    def load(self, jinja_environment):
+        """Load properties that can vary depending on content of the file"""
+        self.references = []
+
     def render(self, output_path, jinja_environment):
         self.output_path = self._render_to_output(output_path, jinja_environment)
 

--- a/combine/files/html.py
+++ b/combine/files/html.py
@@ -44,8 +44,6 @@ class HTMLFile(File):
         with open(target_path, "w+") as f:
             f.write(template.render(url=self._get_url()))
 
-        self.load(jinja_environment)
-
         return target_path
 
     def _get_url(self):

--- a/combine/files/html.py
+++ b/combine/files/html.py
@@ -32,6 +32,9 @@ class HTMLFile(File):
 
         return os.path.join(*self.root_parts, "index.html")
 
+    def load(self, jinja_environment):
+        self.references = get_references_in_path(self.path, jinja_environment)
+
     def _render_to_output(self, output_path, jinja_environment):
         target_path = os.path.join(output_path, self.output_relative_path)
         create_parent_directory(target_path)
@@ -41,7 +44,7 @@ class HTMLFile(File):
         with open(target_path, "w+") as f:
             f.write(template.render(url=self._get_url()))
 
-        self.references = get_references_in_path(self.path, jinja_environment)
+        self.load(jinja_environment)
 
         return target_path
 

--- a/combine/files/markdown.py
+++ b/combine/files/markdown.py
@@ -49,6 +49,4 @@ class MarkdownFile(HTMLFile):
         with open(target_path, "w+") as f:
             f.write(template.render(**variables))
 
-        self.load(jinja_environment)
-
         return target_path

--- a/combine/files/markdown.py
+++ b/combine/files/markdown.py
@@ -18,18 +18,30 @@ class MarkdownFile(HTMLFile):
 
         return os.path.join(*self.root_parts, "index.html")
 
-    def _render_to_output(self, output_path, jinja_environment):
+    def load(self, jinja_environment):
+        template = self._get_jinja_template(jinja_environment, self._get_variables())
+        self.references = [
+            os.path.basename(template.filename)
+        ] + get_references_in_path(template.filename, jinja_environment)
+
+    def _get_variables(self):
         post = frontmatter.load(self.path)
 
         variables = post.metadata
         variables["url"] = self._get_url()
         variables["content"] = post.content
 
-        # TODO can post.content be jinja rendered to use variables?
+        return variables
 
-        # an optional way to override
+    def _get_jinja_template(self, jinja_environment, variables):
         template_name = variables.get("template", "markdown.template.html")
-        template = jinja_environment.get_template(template_name)
+        return jinja_environment.get_template(template_name)
+
+    def _render_to_output(self, output_path, jinja_environment):
+        variables = self._get_variables()
+
+        # TODO can post.content be jinja rendered to use variables?
+        template = self._get_jinja_template(jinja_environment, variables)
 
         target_path = os.path.join(output_path, self.output_relative_path)
         create_parent_directory(target_path)
@@ -37,8 +49,6 @@ class MarkdownFile(HTMLFile):
         with open(target_path, "w+") as f:
             f.write(template.render(**variables))
 
-        self.references = [template_name] + get_references_in_path(
-            template.filename, jinja_environment
-        )
+        self.load(jinja_environment)
 
         return target_path

--- a/combine/files/template.py
+++ b/combine/files/template.py
@@ -7,4 +7,4 @@ class TemplateFile(IgnoredFile):
         self.references = get_references_in_path(self.path, jinja_environment)
 
     def _render_to_output(self, output_path, jinja_environment):
-        self.load(jinja_environment)
+        pass

--- a/combine/files/template.py
+++ b/combine/files/template.py
@@ -3,5 +3,8 @@ from .ignored import IgnoredFile
 
 
 class TemplateFile(IgnoredFile):
-    def _render_to_output(self, output_path, jinja_environment):
+    def load(self, jinja_environment):
         self.references = get_references_in_path(self.path, jinja_environment)
+
+    def _render_to_output(self, output_path, jinja_environment):
+        self.load(jinja_environment)


### PR DESCRIPTION
Allows the `watch` command to know file references even though it hasn't built anything.